### PR TITLE
Add support for non-ID based entities in BaseSoftDao

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# v2.2.0
+Added support for non Id Based entities, in the BaseSoftDao class. This allows for the use of non Id based entities in the BaseSoftDao class. 
+This is useful for entities that do not have a Id property, such as a composite key or a key that is not an integer.
+The following classes were added:
+
+```c#
+	BaseNonIdDao<T> : IBaseDao<T> where T: class, IBaseEntity
+	BaseSoftNonIdDao<T> : BaseNonIdDao<T>, IBaseDao<T> where T : class, IBaseSoftEntity
+```
+Similarly to the other Soft Dao classes, these classes will use the SoftDelete property to mark the entity as deleted, rather than actually deleting it from the database.
+You won't have to manage the Created, Updated, or Deleted dates manually unless you override the methods in the BaseDao class.
+
+
 # v2.1.1
 Updated BaseDataAccess to use the new interface for IBaseSoftIdEntity and removed the interface from this project.
 Fixed a bug where the BaseSoft Daos were not using the correct base class.

--- a/ProphetsWay.EFTools/BaseNonIdDao.cs
+++ b/ProphetsWay.EFTools/BaseNonIdDao.cs
@@ -1,0 +1,54 @@
+﻿#if NET8_0_OR_GREATER
+using Microsoft.EntityFrameworkCore;
+#endif
+#if NET461 || NET471 || NET48
+using System.Data.Entity;
+#endif
+using ProphetsWay.BaseDataAccess;
+
+using System.Linq;
+
+namespace ProphetsWay.EFTools
+{
+    public abstract class BaseNonIdDao<T> : IBaseDao<T> where T: class, IBaseEntity
+    {
+        internal RootNonIdDao<T> Dao;
+
+        protected BaseNonIdDao(DbContext context)
+        {
+            Dao = new RootNonIdDao<T>(context);
+        }
+
+        public DbContext Context => Dao.Context;
+        public DbSet<T> Dataset => Dao.Dataset;
+
+        public int Delete(T item)
+        {
+            return Dao.Delete(item);
+        }
+
+        public abstract T Get(T item);
+
+        public void Insert(T item)
+        {
+            Dao.Insert(item);
+        }
+
+        public abstract int Update(T item);
+
+        public void EnsureBeginTransaction()
+        {
+            Dao.EnsureBeginTransaction();
+        }
+
+        public void EnsureTransactionCommit()
+        {
+            Dao.EnsureTransactionCommit();
+        }
+
+        public void EnsureTransactionRollback()
+        {
+            Dao.EnsureTransactionRollback();
+        }
+    }
+}

--- a/ProphetsWay.EFTools/BaseSoftNonIdDao.cs
+++ b/ProphetsWay.EFTools/BaseSoftNonIdDao.cs
@@ -1,0 +1,79 @@
+﻿#if NET8_0_OR_GREATER
+using Microsoft.EntityFrameworkCore;
+#endif
+#if NET461 || NET471 || NET48
+using System.Data.Entity;
+using System.Data.Entity.Migrations;
+#endif
+using ProphetsWay.BaseDataAccess;
+using System;
+
+namespace ProphetsWay.EFTools
+{
+    public abstract class BaseSoftNonIdDao<T> : BaseNonIdDao<T>, IBaseDao<T> where T : class, IBaseSoftEntity
+    {
+        protected BaseSoftNonIdDao(DbContext context, bool UseUtcTime = true) : base(context)
+        {
+            this.UseUtcTime = UseUtcTime;
+        }
+
+        protected bool UseUtcTime { get; private set; }
+
+#if NET461 || NET471 || NET48
+        public override int Update(T item)
+        {
+            item.UpdatedDate = UseUtcTime ? DateTime.UtcNow : DateTime.Now;
+            return UpdateEntity(item);
+        }
+#endif
+#if NET8_0_OR_GREATER
+        public override int Update(T item)
+        {
+            item.UpdatedDate = UseUtcTime ? DateTime.UtcNow : DateTime.Now;
+            return UpdateEntity(item);
+        }
+
+        public override T Get(T item)
+        {
+            return Get(item, false);
+        }
+
+        /// <summary>
+        /// Need to retrieve the entity by its ID(s) so we can update it.
+        /// when AsTracking is true, must use AsTracking() to get the entity
+        ///     return Dataset.AsTracking().Single(x=> x.Key1 == item.Key1 && x.Key2 == item.Key2);
+        /// else
+        ///     return Dataset.Single(x=> x.Key1 == item.Key1 && x.Key2 == item.Key2);
+        /// </summary>
+        public abstract T Get(T item, bool AsTracking);
+#endif
+
+        private int UpdateEntity(T item)
+        {
+#if NET461 || NET471 || NET48
+            Dao.Dataset.AddOrUpdate(item);
+#endif
+#if NET8_0_OR_GREATER
+            var entity = Get(item, true);
+            var entityEntry = Dao.Context.Entry(entity);
+            entityEntry.CurrentValues.SetValues(item);
+            entityEntry.State = EntityState.Modified;
+#endif
+            return Dao.Context.SaveChanges();
+        }
+
+        public new int Delete(T item)
+        {
+            item.DeletedDate = UseUtcTime ? DateTime.UtcNow : DateTime.Now;
+            return UpdateEntity(item);
+        }
+
+        public new void Insert(T item)
+        {
+            item.CreatedDate = UseUtcTime ? DateTime.UtcNow : DateTime.Now;
+            Dao.Insert(item);
+        }
+
+
+    }
+}

--- a/ProphetsWay.EFTools/ProphetsWay.EFTools.csproj
+++ b/ProphetsWay.EFTools/ProphetsWay.EFTools.csproj
@@ -59,7 +59,7 @@ For more information on this project, please go to https://github.com/ProphetMan
 	</ItemGroup>
 	
 	<ItemGroup>
-		<PackageReference Include="ProphetsWay.BaseDataAccess" Version="2.4.0" />
+		<PackageReference Include="ProphetsWay.BaseDataAccess" Version="2.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ProphetsWay.EFTools/RootDao.cs
+++ b/ProphetsWay.EFTools/RootDao.cs
@@ -1,6 +1,5 @@
 ﻿#if NET8_0_OR_GREATER 
 using Microsoft.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore.Storage;
 #endif
 #if NET461 || NET471 || NET48
 using System.Data.Entity;
@@ -12,37 +11,9 @@ using System.Linq;
 
 namespace ProphetsWay.EFTools
 {
-	internal class RootDao <T, TIdType> where T : class, IBaseIdEntity<TIdType> where TIdType : struct
+	internal class RootDao <T, TIdType> : RootNonIdDao<T> where T : class, IBaseIdEntity<TIdType> where TIdType : struct
 	{
-		public DbContext Context { get; }
-
-		public DbSet<T> Dataset { get; }
-
-#if NET8_0_OR_GREATER
-		private IDbContextTransaction _transaction;
-#endif
-#if NET461 || NET471 || NET48
-        private DbContextTransaction _transaction;
-#endif
-
-		internal RootDao(DbContext context)
-		{
-			Context = context;
-			Dataset = Context.Set<T>();
-			_transaction = null;
-		}
-
-		public int Delete(T item)
-		{
-			Dataset.Remove(item);
-			return Context.SaveChanges();
-		}
-
-		public void Insert(T item)
-		{
-			Dataset.Add(item);
-			Context.SaveChanges();
-		}
+		internal RootDao(DbContext context) : base(context) { }
 
 		public int Update(T item)
 		{
@@ -73,26 +44,6 @@ namespace ProphetsWay.EFTools
 		public IList<T> GetPaged(T item, int skip, int take)
 		{
 			return Dataset.OrderBy(x => x.Id).Skip(skip).Take(take).ToList();
-		}
-
-		public void EnsureBeginTransaction()
-		{
-			if (Context.Database.CurrentTransaction == null)
-			{
-				_transaction = Context.Database.BeginTransaction();
-			}
-		}
-
-		public void EnsureTransactionCommit()
-		{
-			_transaction?.Commit();
-			_transaction = null;
-		}
-
-		public void EnsureTransactionRollback()
-		{
-			_transaction?.Rollback();
-			_transaction = null;
 		}
 	}
 }

--- a/ProphetsWay.EFTools/RootNonIdDao.cs
+++ b/ProphetsWay.EFTools/RootNonIdDao.cs
@@ -1,0 +1,64 @@
+﻿#if NET8_0_OR_GREATER 
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Storage;
+#endif
+#if NET461 || NET471 || NET48
+using System.Data.Entity;
+#endif
+using ProphetsWay.BaseDataAccess;
+
+namespace ProphetsWay.EFTools
+{
+	internal class RootNonIdDao <T> where T : class, IBaseEntity
+	{
+		public DbContext Context { get; }
+
+		public DbSet<T> Dataset { get; }
+
+#if NET8_0_OR_GREATER
+		private IDbContextTransaction _transaction;
+#endif
+#if NET461 || NET471 || NET48
+        private DbContextTransaction _transaction;
+#endif
+
+		internal RootNonIdDao(DbContext context)
+		{
+			Context = context;
+			Dataset = Context.Set<T>();
+			_transaction = null;
+		}
+
+		public int Delete(T item)
+		{
+			Dataset.Remove(item);
+			return Context.SaveChanges();
+		}
+
+		public void Insert(T item)
+		{
+			Dataset.Add(item);
+			Context.SaveChanges();
+		}
+
+		public void EnsureBeginTransaction()
+		{
+			if (Context.Database.CurrentTransaction == null)
+			{
+				_transaction = Context.Database.BeginTransaction();
+			}
+		}
+
+		public void EnsureTransactionCommit()
+		{
+			_transaction?.Commit();
+			_transaction = null;
+		}
+
+		public void EnsureTransactionRollback()
+		{
+			_transaction?.Rollback();
+			_transaction = null;
+		}
+	}
+}

--- a/ProphetsWay.Example.DataAccess.EF/ProphetsWay.Example.DataAccess.EF.csproj
+++ b/ProphetsWay.Example.DataAccess.EF/ProphetsWay.Example.DataAccess.EF.csproj
@@ -20,7 +20,7 @@
 	
 	<ItemGroup>
 		<PackageReference Include="FluentAssertions" Version="8.2.0" />
-		<PackageReference Include="ProphetsWay.BaseDataAccess" Version="2.4.0" />
+		<PackageReference Include="ProphetsWay.BaseDataAccess" Version="2.5.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/app-variables.yml
+++ b/app-variables.yml
@@ -1,8 +1,8 @@
 variables:
   #user must update these each build personally as new versions are being worked on
   Major: '2'
-  Minor: '1'
-  Patch: '1'
+  Minor: '2'
+  Patch: '0'
 
   # set these once and forget them per project/repo 
   #HasSqlProj: ''  #can be empty or ignored if unnecessary, but if "yes" then pipeline will find any *.sqlproj projects and build them 


### PR DESCRIPTION
This update introduces `BaseNonIdDao<T>` and `BaseSoftNonIdDao<T>` classes to handle entities without traditional ID properties, accommodating composite keys and non-integer keys. The `RootDao` class now inherits from `RootNonIdDao<T>`, with several transaction management and entity operation methods updated or removed for improved code clarity. The `ProphetsWay.BaseDataAccess` package version has been upgraded from `2.4.0` to `2.5.0`, and the changelog has been updated accordingly.

#15